### PR TITLE
Fix - Window Token Exception 

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateDialog.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateDialog.java
@@ -153,7 +153,7 @@ public class ExpirationDateDialog extends Dialog implements DialogInterface.OnSh
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
-                if (mEditText.isFocused()) {
+                if (mEditText.isFocused() && !ExpirationDateDialog.super.getOwnerActivity().isFinishing()) {
                     ExpirationDateDialog.super.show();
                 }
             }

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateDialog.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateDialog.java
@@ -153,7 +153,8 @@ public class ExpirationDateDialog extends Dialog implements DialogInterface.OnSh
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
-                if (mEditText.isFocused() && !ExpirationDateDialog.super.getOwnerActivity().isFinishing()) {
+                Activity ownerActivity = ExpirationDateDialog.this.getOwnerActivity();
+                if (mEditText.isFocused() && ownerActivity != null && !ownerActivity.isFinishing()) {
                     ExpirationDateDialog.super.show();
                 }
             }


### PR DESCRIPTION
android.view.WindowManager$BadTokenException: occurs when user leaves the form half filled and exits the activity. The expiration date dialog should check if the activity is finishing before deciding to call it's parent show function.

Please let me know if I should change anything, this is my first pull request to another library in a while so I may have made mistakes.