### PR TITLE
Makes possible to use date dialog without whole form

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
@@ -201,7 +201,7 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
         mPostalCodeIcon.setImageResource(isDarkBackground ? R.drawable.bt_ic_postal_code_dark : R.drawable.bt_ic_postal_code);
         mMobileNumberIcon.setImageResource(isDarkBackground? R.drawable.bt_ic_mobile_number_dark : R.drawable.bt_ic_mobile_number);
 
-        mExpiration.setActivity(activity);
+        mExpiration.useDialogForExpirationDateEntry(activity, true);
 
         setViewVisibility(mCardNumberIcon, mCardNumberRequired);
         setFieldVisibility(mCardNumber, mCardNumberRequired);

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateEditText.java
@@ -56,6 +56,12 @@ public class ExpirationDateEditText extends ErrorEditText implements TextWatcher
         super.setOnClickListener(this);
     }
 
+    /**
+     * Used to set an activity for the expiration date dialog. Must be set in order to use the
+     * dialog for expiration date entry.
+     *
+     * @param activity used as the parent activity for the dialog
+     */
     public void setActivity(Activity activity) {
         mExpirationDateDialog = ExpirationDateDialog.create(activity, this);
     }

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateEditText.java
@@ -28,7 +28,7 @@ public class ExpirationDateEditText extends ErrorEditText implements TextWatcher
 
     private boolean mChangeWasAddition;
     private OnClickListener mClickListener;
-    private boolean mUseExpirationDateDialog = true;
+    private boolean mUseExpirationDateDialog = false;
     private ExpirationDateDialog mExpirationDateDialog;
 
     public ExpirationDateEditText(Context context) {
@@ -57,18 +57,8 @@ public class ExpirationDateEditText extends ErrorEditText implements TextWatcher
     }
 
     /**
-     * Used to set an activity for the expiration date dialog. Must be set in order to use the
-     * dialog for expiration date entry.
-     *
-     * @param activity used as the parent activity for the dialog
-     */
-    public void setActivity(Activity activity) {
-        mExpirationDateDialog = ExpirationDateDialog.create(activity, this);
-    }
-
-    /**
-     * Used to enable or disable entry of the expiration date using a dialog. Defaults to using the
-     * dialog.
+     * Used to enable or disable entry of the expiration date using {@link ExpirationDateDialog}.
+     * Defaults to false.
      *
      * @param activity used as the parent activity for the dialog
      * @param useDialog {@code false} to use a numeric keyboard to enter the expiration date,

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/ExpirationDateEditText.java
@@ -56,7 +56,7 @@ public class ExpirationDateEditText extends ErrorEditText implements TextWatcher
         super.setOnClickListener(this);
     }
 
-    protected void setActivity(Activity activity) {
+    public void setActivity(Activity activity) {
         mExpirationDateDialog = ExpirationDateDialog.create(activity, this);
     }
 


### PR DESCRIPTION
Not sure if it's intentional, but I wanted to use not whole form but just the custom views (because it's easier than style the whole form).

Since the method is protected, I'm not able to show the dialog for selecting date.
Workaround is to extend the view and override the method to be public.
It's called the same way as from `CardForm#setup(Activity)` method.