### PR TITLE
Input Masking

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardNumberTransformation.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardNumberTransformation.java
@@ -1,0 +1,38 @@
+package com.braintreepayments.cardform.utils;
+
+import android.graphics.Rect;
+import android.text.method.TransformationMethod;
+import android.view.View;
+
+import java.util.Arrays;
+
+/**
+ * A transformation that masks card numbers up to the last 4 digits. For example, it will transform
+ * "4111111111111111" to "●●●● 1111". This can be used to mask card numbers in an {@link android.widget.EditText}.
+ */
+public class CardNumberTransformation implements TransformationMethod {
+
+    private static final String FOUR_DOTS = "••••";
+
+    @Override
+    public CharSequence getTransformation(final CharSequence source, View view) {
+        if (source.length() >= 9) {
+            StringBuilder result = new StringBuilder()
+                    .append(FOUR_DOTS)
+                    .append(" ")
+                    .append(source.subSequence(source.length() - 4, source.length()));
+
+            char[] padding = new char[source.length() - result.length()];
+            Arrays.fill(padding, Character.MIN_VALUE);
+            result.insert(0, padding);
+
+            return result.toString();
+        }
+
+        return source;
+    }
+
+    @Override
+    public void onFocusChanged(View view, CharSequence sourceText, boolean focused, int direction, Rect previouslyFocusedRect) {}
+}
+

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
@@ -182,6 +182,22 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
     }
 
     /**
+     * @param mask if {@code true}, card number input will be masked.
+     */
+    public CardForm maskCardNumber(boolean mask) {
+        mCardNumber.setMask(mask);
+        return this;
+    }
+
+    /**
+     * @param mask if {@code true}, CVV input will be masked.
+     */
+    public CardForm maskCvv(boolean mask) {
+        mCvv.setMask(mask);
+        return this;
+    }
+
+    /**
      * Sets up the card form for display to the user using the values provided in {@link CardForm#cardRequired(boolean)},
      * {@link CardForm#expirationRequired(boolean)}, ect. If {@link #setup(android.app.Activity)} is not called,
      * the form will not be visible.

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CvvEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CvvEditText.java
@@ -61,6 +61,17 @@ public class CvvEditText extends ErrorEditText implements TextWatcher {
         invalidate();
     }
 
+    /**
+     * @param mask if {@code true}, this field will be masked.
+     */
+    public void setMask(boolean mask) {
+        if (mask) {
+            setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_VARIATION_PASSWORD);
+        } else {
+            setInputType(InputType.TYPE_CLASS_NUMBER);
+        }
+    }
+
     @Override
     public void afterTextChanged(Editable editable) {
         if (mCardType == null) {

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/ErrorEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/ErrorEditText.java
@@ -53,7 +53,9 @@ public class ErrorEditText extends TextInputEditText {
     @Override
     public void onTextChanged(CharSequence text, int start, int lengthBefore, int lengthAfter) {
         super.onTextChanged(text, start, lengthBefore, lengthAfter);
-        setError(null);
+        if (lengthBefore != lengthAfter) {
+            setError(null);
+        }
     }
 
     @Override

--- a/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardNumberTransformationTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardNumberTransformationTest.java
@@ -1,0 +1,27 @@
+package com.braintreepayments.cardform.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricTestRunner.class)
+public class CardNumberTransformationTest {
+
+    CardNumberTransformation mTransform = new CardNumberTransformation();
+
+    @Test
+    public void masksCardNumber() {
+        String transformed = (String) mTransform.getTransformation("4111111111111111", null);
+
+        assertEquals("\u0000\u0000\u0000\u0000\u0000\u0000\u0000•••• 1111", transformed);
+    }
+
+    @Test
+    public void doesNotMaskCardNumbersSmallerThanNineCharacters() {
+        String transformed = (String) mTransform.getTransformation("41111111", null);
+
+        assertEquals("41111111", transformed);
+    }
+}

--- a/CardForm/src/test/java/com/braintreepayments/cardform/view/CvvEditTextTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/view/CvvEditTextTest.java
@@ -2,6 +2,7 @@ package com.braintreepayments.cardform.view;
 
 import android.support.design.widget.TextInputLayout;
 import android.text.Editable;
+import android.text.InputType;
 
 import com.braintreepayments.cardform.R;
 import com.braintreepayments.cardform.test.TestActivity;
@@ -66,6 +67,27 @@ public class CvvEditTextTest {
             assertEquals(RuntimeEnvironment.application.getString(cardType.getSecurityCodeName()),
                     mView.getContentDescription());
         }
+    }
+
+    @Test
+    public void appliesPasswordInputTypeWhenMasked() {
+        mView.setMask(true);
+
+        assertEquals(InputType.TYPE_NUMBER_VARIATION_PASSWORD | InputType.TYPE_CLASS_NUMBER, mView.getInputType());
+    }
+
+    @Test
+    public void doesNotApplyPasswordInputTypeWhenNotMasked() {
+        assertEquals(InputType.TYPE_CLASS_NUMBER, mView.getInputType());
+    }
+
+    @Test
+    public void appliesNumberInputTypeWhenUnmasked() {
+        mView.setMask(true);
+        assertEquals(InputType.TYPE_NUMBER_VARIATION_PASSWORD | InputType.TYPE_CLASS_NUMBER, mView.getInputType());
+
+        mView.setMask(false);
+        assertEquals(InputType.TYPE_CLASS_NUMBER, mView.getInputType());
     }
 
     @Test

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.0'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId 'com.braintreepayments.sample'
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName '1.0.0'
     }
@@ -23,7 +23,7 @@ android {
 dependencies {
     compile project(':CardForm')
 
-    compile 'com.android.support:appcompat-v7:26.0.0'
+    compile 'com.android.support:appcompat-v7:27.0.0'
 
     compile 'com.squareup.leakcanary:leakcanary-android:1.4'
     compile 'com.facebook.stetho:stetho:1.5.0'

--- a/Sample/src/main/java/com/braintreepayments/sample/BaseCardFormActivity.java
+++ b/Sample/src/main/java/com/braintreepayments/sample/BaseCardFormActivity.java
@@ -32,6 +32,8 @@ public class BaseCardFormActivity extends AppCompatActivity implements OnCardFor
 
         mCardForm = findViewById(R.id.card_form);
         mCardForm.cardRequired(true)
+                .maskCardNumber(true)
+                .maskCvv(true)
                 .expirationRequired(true)
                 .cvvRequired(true)
                 .postalCodeRequired(true)


### PR DESCRIPTION
Enables input masking for:
* CardEditText
* CvvEditText

Card numbers are masked as "••••" + last four digits after focus changes.
Cvv edit texts are masked as a standard password.

cc:
@skunkworks 