### PR TITLE
Update CardType.validate to also check relaxed prefixes

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
@@ -220,7 +220,7 @@ public enum CardType {
         final int numberLength = cardNumber.length();
         if (numberLength < mMinCardLength || numberLength > mMaxCardLength) {
             return false;
-        } else if (!mPattern.matcher(cardNumber).matches()) {
+        } else if (!mPattern.matcher(cardNumber).matches() && !mRelaxedPrefixPattern.matcher(cardNumber).matches()) {
             return false;
         }
         return isLuhnValid(cardNumber);

--- a/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
@@ -119,7 +119,7 @@ public class CardTypeTest {
     }
 
     @Test
-    public void sampleCards() {
+    public void sampleCardsAreLuhnValid() {
         for (final Map.Entry<String, CardType> entry : SAMPLE_CARDS.entrySet()) {
             final String cardNumber = entry.getKey();
             final CardType cardType = entry.getValue();
@@ -130,6 +130,22 @@ public class CardTypeTest {
             if (cardType != CardType.UNKNOWN && cardType != CardType.EMPTY) {
                 assertTrue(String.format("%s: Luhn check failed for [%s]", cardType, cardNumber),
                         CardType.isLuhnValid(cardNumber));
+            }
+        }
+    }
+
+    @Test
+    public void validateSampleCards() {
+        for (final Map.Entry<String, CardType> entry : SAMPLE_CARDS.entrySet()) {
+            final String cardNumber = entry.getKey();
+            final CardType cardType = entry.getValue();
+            final CardType actualType = CardType.forCardNumber(cardNumber);
+
+            assertEquals(String.format("CardType.forAccountNumber failed for %s", cardNumber), cardType, actualType);
+
+            if (cardType != CardType.UNKNOWN && cardType != CardType.EMPTY) {
+                assertTrue(String.format("%s: Validate check failed for [%s]", cardType, cardNumber),
+                        cardType.validate(cardNumber));
             }
         }
     }


### PR DESCRIPTION
Fixes the issue were `CardType.validate` failed for Maestro numbers starting with a relaxed prefix.

Add test to check the `validate` method for all sample card numbers in CardTypeTest.java