### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ android:
     - tools
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.2
+    - android-28
 before_install:
   - yes | sdkmanager "platforms;android-27"
 script: ./gradlew clean lint test

--- a/CardForm/build.gradle
+++ b/CardForm/build.gradle
@@ -6,12 +6,12 @@ apply plugin: 'io.codearte.nexus-staging'
 version '3.4.2-SNAPSHOT'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 40
         versionName version
 
@@ -20,6 +20,7 @@ android {
 
     testOptions {
         unitTests {
+            includeAndroidResources true
             all {
                 jvmArgs '-noverify'
             }
@@ -35,11 +36,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:design:27.0.0'
+    implementation 'com.android.support:design:28.0.0-rc02'
     implementation 'io.card:android-sdk:5.5.1'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.robolectric:robolectric:3.3.2'
+    testImplementation 'org.robolectric:robolectric:3.8'
     testImplementation 'org.mockito:mockito-core:2.8.9'
 }
 

--- a/CardForm/build.gradle
+++ b/CardForm/build.gradle
@@ -35,12 +35,12 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:design:27.0.0'
-    compile 'io.card:android-sdk:5.5.1'
+    implementation 'com.android.support:design:27.0.0'
+    implementation 'io.card:android-sdk:5.5.1'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.3.2'
-    testCompile 'org.mockito:mockito-core:2.8.9'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:3.3.2'
+    testImplementation 'org.mockito:mockito-core:2.8.9'
 }
 
 /* maven release */

--- a/CardForm/src/test/java/com/braintreepayments/cardform/view/ErrorEditTextTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/view/ErrorEditTextTest.java
@@ -35,8 +35,8 @@ public class ErrorEditTextTest {
 
         mView.setFieldHint(R.string.bt_form_hint_cvv);
 
-        assertEquals(((TextInputLayout) mView.getParent().getParent()).getHint(), "CVV");
-        assertNull(mView.getHint());
+        assertEquals("CVV", ((TextInputLayout) mView.getParent().getParent()).getHint());
+        assertEquals("CVV", mView.getHint());
     }
 
     @Test
@@ -46,8 +46,8 @@ public class ErrorEditTextTest {
 
         mView.setFieldHint("CVV");
 
-        assertEquals(((TextInputLayout) mView.getParent().getParent()).getHint(), "CVV");
-        assertNull(mView.getHint());
+        assertEquals("CVV", ((TextInputLayout) mView.getParent().getParent()).getHint());
+        assertEquals("CVV", mView.getHint());
     }
 
     @Test

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -21,10 +21,11 @@ android {
 }
 
 dependencies {
-    compile project(':CardForm')
+    implementation project(':CardForm')
 
-    compile 'com.android.support:appcompat-v7:27.0.0'
+    implementation 'com.android.support:design:27.0.0'
+    implementation 'com.android.support:appcompat-v7:27.0.0'
 
-    compile 'com.squareup.leakcanary:leakcanary-android:1.4'
-    compile 'com.facebook.stetho:stetho:1.5.0'
+    implementation 'com.squareup.leakcanary:leakcanary-android:1.4'
+    implementation 'com.facebook.stetho:stetho:1.5.0'
 }

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.2'
 
     defaultConfig {
         applicationId 'com.braintreepayments.sample'
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName '1.0.0'
     }
@@ -23,8 +23,8 @@ android {
 dependencies {
     implementation project(':CardForm')
 
-    implementation 'com.android.support:design:27.0.0'
-    implementation 'com.android.support:appcompat-v7:27.0.0'
+    implementation 'com.android.support:design:28.0.0-rc02'
+    implementation 'com.android.support:appcompat-v7:28.0.0-rc02'
 
     implementation 'com.squareup.leakcanary:leakcanary-android:1.4'
     implementation 'com.facebook.stetho:stetho:1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,18 +1,17 @@
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3'
     }
 }
 
 allprojects {
     repositories {
+        google()
         jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 07 09:45:48 EST 2017
+#Fri Sep 07 14:51:56 PDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
Doing some pre-P base work:

* Bump to API 28
* Bump Gradle 4.4
* Bump roboelectric
* Add Google maven repository
* Replace deprecated `compile` dependency keywords
* Bump android dependencies on Travis

In API 28 it seems to return the hint set on the `TextInputLayout` back through to the `View`, so I updated that test.