### PR TITLE
Prevent NPE when not setting supported card types

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/SupportedCardTypesView.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/SupportedCardTypesView.java
@@ -11,6 +11,7 @@ import android.widget.TextView;
 
 import com.braintreepayments.cardform.utils.CardType;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -20,7 +21,7 @@ import java.util.List;
 @SuppressLint("AppCompatCustomView")
 public class SupportedCardTypesView extends TextView {
 
-    private List<CardType> mSupportedCardTypes;
+    private List<CardType> mSupportedCardTypes = new ArrayList<>();
 
     public SupportedCardTypesView(Context context) {
         super(context);
@@ -49,10 +50,23 @@ public class SupportedCardTypesView extends TextView {
             cardTypes = new CardType[]{};
         }
 
-        mSupportedCardTypes = Arrays.asList(cardTypes);
+        mSupportedCardTypes.clear();
+        mSupportedCardTypes.addAll(Arrays.asList(cardTypes));
+
         setSelected(cardTypes);
     }
 
+    /**
+     * Selects the intersection between the {@link CardType}s passed into
+     * {@link #setSupportedCardTypes(CardType...)} and {@link CardType}s passed into
+     * this method as visually enabled.
+     *
+     * The remaining supported card types will become visually disabled.
+     *
+     * {@link #setSupportedCardTypes(CardType...)} must be called prior to using this method.
+     *
+     * @param cardTypes The {@link CardType}s to set as visually enabled.
+     */
     public void setSelected(@Nullable CardType... cardTypes) {
         if (cardTypes == null) {
             cardTypes = new CardType[]{};

--- a/CardForm/src/test/java/com/braintreepayments/cardform/view/SupportedCardTypesViewTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/view/SupportedCardTypesViewTest.java
@@ -88,4 +88,13 @@ public class SupportedCardTypesViewTest {
         assertTrue(allSpans.get(6).isDisabled());
         assertTrue(allSpans.get(7).isDisabled());
     }
+
+    @Test
+    public void setSelected_withoutSetSupportedCardTypes_returnsEmptyText() {
+        SupportedCardTypesView supportedCardTypesView = new SupportedCardTypesView(RuntimeEnvironment.application);
+
+        supportedCardTypesView.setSelected(CardType.VISA);
+
+        assertEquals("", supportedCardTypesView.getText().toString());
+    }
 }

--- a/CardForm/src/test/java/com/braintreepayments/cardform/view/SupportedCardTypesViewTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/view/SupportedCardTypesViewTest.java
@@ -90,7 +90,7 @@ public class SupportedCardTypesViewTest {
     }
 
     @Test
-    public void setSelected_withoutSetSupportedCardTypes_returnsEmptyText() {
+    public void setSelected_withoutSettingSupportedCardTypes_doesNothing() {
         SupportedCardTypesView supportedCardTypesView = new SupportedCardTypesView(RuntimeEnvironment.application);
 
         supportedCardTypesView.setSelected(CardType.VISA);


### PR DESCRIPTION
This will allow the view to function as an empty view. Integrators
should check the JavaDoc as part of the debugging process and read that
setSupportedCardTypes should be called first.

Fixes #58