### PR TITLE
Fix validate NullPointerException

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
@@ -215,6 +215,8 @@ public enum CardType {
     public boolean validate(String cardNumber) {
         if (TextUtils.isEmpty(cardNumber)) {
             return false;
+        } else if (!TextUtils.isDigitsOnly(cardNumber)) {
+            return false;
         }
 
         final int numberLength = cardNumber.length();

--- a/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
@@ -222,7 +222,7 @@ public enum CardType {
         final int numberLength = cardNumber.length();
         if (numberLength < mMinCardLength || numberLength > mMaxCardLength) {
             return false;
-        } else if (!mPattern.matcher(cardNumber).matches() && !mRelaxedPrefixPattern.matcher(cardNumber).matches()) {
+        } else if (!mPattern.matcher(cardNumber).matches() && mRelaxedPrefixPattern != null && !mRelaxedPrefixPattern.matcher(cardNumber).matches()) {
             return false;
         }
         return isLuhnValid(cardNumber);

--- a/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
@@ -165,4 +165,9 @@ public class CardTypeTest {
         assertFalse(CardType.UNKNOWN.validate("Not-A-Number"));
         assertFalse(CardType.UNKNOWN.validate("@#$%^&"));
     }
+
+    @Test
+    public void validate_whenPatternFailsAndNoRelaxedPatternExists_returnsFalse() {
+        assertFalse(CardType.VISA.validate("9999999999999999"));
+    }
 }

--- a/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(RobolectricTestRunner.class)
 public class CardTypeTest {
@@ -156,5 +157,12 @@ public class CardTypeTest {
                         cardType.validate(cardNumber));
             }
         }
+    }
+
+    @Test
+    public void validate_whenGivenNonDigits_returnsFalse() {
+        assertFalse(CardType.UNKNOWN.validate(""));
+        assertFalse(CardType.UNKNOWN.validate("Not-A-Number"));
+        assertFalse(CardType.UNKNOWN.validate("@#$%^&"));
     }
 }


### PR DESCRIPTION
Validate checks if the main pattern doesn't match, that a relaxed pattern may match. This relaxed pattern is optional and could be null, resulting in a NPE if the pattern doesn't match.

During testing I realized we don't return false if the pattern is not digits only until the luhn validate, and at that point we throw an exception. The proper thing would have an initial check that the card number is digits only.