### PR TITLE
Cardholder Name Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Android Card Form Release Notes
 
+## unreleased
+  * Validate Cardholder Name field to prevent sensitive data from being input
+
 ## 5.1.0
   * Bump `compileSdkVersion` and `targetSdkVersion` to API level 30
   * Add support for Maestro cards beginning in 5043

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CardholderNameEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CardholderNameEditText.java
@@ -1,6 +1,7 @@
 package com.braintreepayments.cardform.view;
 
 import android.content.Context;
+import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputFilter.LengthFilter;
 import android.text.InputType;
@@ -8,10 +9,14 @@ import android.util.AttributeSet;
 
 import com.braintreepayments.cardform.R;
 
+import java.util.regex.Pattern;
+
 /**
  * Input for cardholder name. Validated for presence only.
  */
 public class CardholderNameEditText extends ErrorEditText {
+
+    private static final Pattern sensitiveDataRegex = Pattern.compile("^[\\d\\s-]+$");
 
     public CardholderNameEditText(Context context) {
         super(context);
@@ -36,16 +41,24 @@ public class CardholderNameEditText extends ErrorEditText {
 
     @Override
     public boolean isValid() {
-        return isOptional() || !isTextEmpty() || !isPotentiallySensitiveInformation();
+        if (isOptional()) {
+            return hasValidCardholderNameText();
+        } else {
+            return !isTextEmpty() && hasValidCardholderNameText();
+        }
     }
 
     private boolean isTextEmpty() {
         return getText().toString().trim().isEmpty();
     }
 
-    private boolean isPotentiallySensitiveInformation() {
-        // TODO: implement
-        return false;
+    private boolean hasValidCardholderNameText() {
+        Editable text = getText();
+        if (text != null) {
+            return !sensitiveDataRegex.matcher(text).matches();
+        }
+        // empty text does not contain sensitive data
+        return true;
     }
 
     @Override

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CardholderNameEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CardholderNameEditText.java
@@ -36,7 +36,16 @@ public class CardholderNameEditText extends ErrorEditText {
 
     @Override
     public boolean isValid() {
-        return isOptional() || !getText().toString().trim().isEmpty();
+        return isOptional() || !isTextEmpty() || !isPotentiallySensitiveInformation();
+    }
+
+    private boolean isTextEmpty() {
+        return getText().toString().trim().isEmpty();
+    }
+
+    private boolean isPotentiallySensitiveInformation() {
+        // TODO: implement
+        return false;
     }
 
     @Override

--- a/CardForm/src/test/java/com/braintreepayments/cardform/view/CardholderNameEditTextTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/view/CardholderNameEditTextTest.java
@@ -28,21 +28,43 @@ public class CardholderNameEditTextTest {
     }
 
     @Test
-    public void invalidIfEmpty() {
+    public void isValid_isRequiredByDefault() {
+        assertFalse(mView.isOptional());
+    }
+
+    @Test
+    public void isValid_whenIsRequiredAndTextIsEmpty_returnsFalse() {
         assertFalse(mView.isValid());
     }
 
     @Test
-    public void validIfNotEmpty() {
+    public void isValid_whenIsRequiredAndTextIsNotEmpty_returnsTrue() {
         mView.setText("John Doe");
         assertTrue(mView.isValid());
     }
 
     @Test
-    public void validIfEmptyAndOptional() {
+    public void isValid_whenIsOptionalAndTextIsEmpty_returnsTrue() {
         mView.setOptional(true);
-
         assertTrue(mView.isValid());
+    }
+
+    @Test
+    public void isValid_whenIsRequiredAndIsAlphanumericWithSpaces_returnsTrue() {
+        mView.setText("Jane Doe 123");
+        assertTrue(mView.isValid());
+    }
+
+    @Test
+    public void isValid_whenIsRequiredAndIsOnlyNumericWithHyphensAndSpaces_returnsFalse() {
+        mView.setText("4111-111-1111 1111");
+        assertFalse(mView.isValid());
+    }
+
+    @Test
+    public void isValid_whenIsOptionalAndIsOnlyNumericWithHyphensAndSpaces_returnsFalse() {
+        mView.setText("4111-111-1111 1111");
+        assertFalse(mView.isValid());
     }
 
     @Test

--- a/CardForm/src/test/java/com/braintreepayments/cardform/view/CardholderNameEditTextTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/view/CardholderNameEditTextTest.java
@@ -63,6 +63,7 @@ public class CardholderNameEditTextTest {
 
     @Test
     public void isValid_whenIsOptionalAndIsOnlyNumericWithHyphensAndSpaces_returnsFalse() {
+        mView.setOptional(true);
         mView.setText("4111-111-1111 1111");
         assertFalse(mView.isValid());
     }


### PR DESCRIPTION
### Summary of changes
 - Validate cardholder name to prevent sensitive data from being sent by the user. See [related iOS PR](https://github.com/braintree/braintree-ios-drop-in/pull/303).

### Checklist
 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @sshropshire
