### PR TITLE
Increase Discover Card Range to 19 Digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Android Card Form Release Notes
 
+## unreleased
+  * Increase valid Discover card length to 19 digits
+
 ## 5.1.1
   * Validate Cardholder Name field to prevent sensitive data from being input
 

--- a/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/utils/CardType.java
@@ -21,7 +21,7 @@ public enum CardType {
             3, R.string.bt_cvc, null),
     DISCOVER("^(6011|65|64[4-9]|622)\\d*",
             R.drawable.bt_ic_discover,
-            16, 16,
+            16, 19,
             3, R.string.bt_cid, null),
     AMEX("^3[47]\\d*",
             R.drawable.bt_ic_amex,

--- a/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/utils/CardTypeTest.java
@@ -49,6 +49,7 @@ public class CardTypeTest {
         // Discover
         SAMPLE_CARDS.put("6011111111111117", CardType.DISCOVER);
         SAMPLE_CARDS.put("6011000990139424", CardType.DISCOVER);
+        SAMPLE_CARDS.put("6500000000000000003", CardType.DISCOVER);
 
         // Amex
         SAMPLE_CARDS.put("378282246310005", CardType.AMEX);

--- a/CardForm/src/test/java/com/braintreepayments/cardform/view/CardEditTextTest.java
+++ b/CardForm/src/test/java/com/braintreepayments/cardform/view/CardEditTextTest.java
@@ -51,7 +51,7 @@ public class CardEditTextTest {
 
     @Test
     public void testDiscover() {
-        helper("6011", "1111 1111 1117", R.drawable.bt_ic_discover, 4, 8, 12);
+        helper("6011", "1111 1111 1111117", R.drawable.bt_ic_discover, 4, 8, 12);
     }
 
     @Test


### PR DESCRIPTION
### Summary of changes
 - Increase valid Discover card length to 19 digits

### Checklist
 - [x] Added a changelog entry

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @sarahkoop 
