### PR TITLE
KEY For Security Flag

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
@@ -82,7 +82,7 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
 
     private boolean mCardNumberRequired;
     private boolean mExpirationRequired;
-    private boolean mSecureFlagRequired;
+    private boolean mSecureFlagRequired = true;
     private boolean mCvvRequired;
     private int mCardholderNameStatus = FIELD_DISABLED;
     private boolean mPostalCodeRequired;
@@ -169,7 +169,7 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
         return this;
     }
     /*
-    * @param required Used to set {@link WindowManager.LayoutParams#FLAG_SECURE} to prevent screenshots
+    * @param required Used to set {@link WindowManager.LayoutParams#FLAG_SECURE} to prevent screenshots. Defaults to {@code true}.
      */
                 
     public CardForm secureFlag(boolean required) {
@@ -288,11 +288,10 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
      * @param activity Used to set {@link WindowManager.LayoutParams#FLAG_SECURE} to prevent screenshots
      */
     public void setup(FragmentActivity activity) {
-                if(mSecureFlagRequired) { 
-                        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                        WindowManager.LayoutParams.FLAG_SECURE);
-                }
-        
+        if(mSecureFlagRequired) { 
+             activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE);
+        }
             
         boolean cardHolderNameVisible = mCardholderNameStatus != FIELD_DISABLED;
         boolean isDarkBackground = ViewUtils.isDarkBackground(activity);

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
@@ -280,9 +280,11 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
      * @param activity Used to set {@link WindowManager.LayoutParams#FLAG_SECURE} to prevent screenshots
      */
     public void setup(FragmentActivity activity) {
-        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+         if (!BuildConfig.DEBUG) {
+               activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE);
-
+        }
+            
         boolean cardHolderNameVisible = mCardholderNameStatus != FIELD_DISABLED;
         boolean isDarkBackground = ViewUtils.isDarkBackground(activity);
         mCardholderNameIcon.setImageResource(isDarkBackground ? R.drawable.bt_ic_cardholder_name_dark: R.drawable.bt_ic_cardholder_name);

--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CardForm.java
@@ -82,6 +82,7 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
 
     private boolean mCardNumberRequired;
     private boolean mExpirationRequired;
+    private boolean mSecureFlagRequired;
     private boolean mCvvRequired;
     private int mCardholderNameStatus = FIELD_DISABLED;
     private boolean mPostalCodeRequired;
@@ -167,8 +168,15 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
         mExpirationRequired = required;
         return this;
     }
-
-    /**
+    /*
+    * @param required Used to set {@link WindowManager.LayoutParams#FLAG_SECURE} to prevent screenshots
+     */
+                
+    public CardForm secureFlag(boolean required) {
+        mSecureFlagRequired = required;
+        return this;
+    }
+        /**
      * @param required {@code true} to show and require a cvv, {@code false} otherwise. Defaults to {@code false}.
      * @return {@link CardForm} for method chaining
      */
@@ -280,10 +288,11 @@ public class CardForm extends LinearLayout implements OnCardTypeChangedListener,
      * @param activity Used to set {@link WindowManager.LayoutParams#FLAG_SECURE} to prevent screenshots
      */
     public void setup(FragmentActivity activity) {
-         if (!BuildConfig.DEBUG) {
-               activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE);
-        }
+                if(mSecureFlagRequired) { 
+                        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,
+                        WindowManager.LayoutParams.FLAG_SECURE);
+                }
+        
             
         boolean cardHolderNameVisible = mCardholderNameStatus != FIELD_DISABLED;
         boolean isDarkBackground = ViewUtils.isDarkBackground(activity);


### PR DESCRIPTION
Thank you for your contribution to Braintree. 

> Before submitting this PR, note that we cannot accept language translation PRs. We support the same languages that are supported by PayPal, and have a dedicated localization team to provide the translations. If there is an error in a specific translation, you may open an issue and we will escalate it to the localization team.

### Summary of changes
 - key for enable or disable secure Flag.

### Checklist
 - [ ] Added a changelog entry

### Authors
> phelipelopesc
-
