### PR TITLE
Accessibility Updates (CVV Edit Text and CheckBox)

### DIFF
--- a/CardForm/src/main/java/com/braintreepayments/cardform/view/CvvEditText.java
+++ b/CardForm/src/main/java/com/braintreepayments/cardform/view/CvvEditText.java
@@ -58,7 +58,6 @@ public class CvvEditText extends ErrorEditText implements TextWatcher {
         InputFilter[] filters = { new LengthFilter(cardType.getSecurityCodeLength()) };
         setFilters(filters);
 
-        setContentDescription(getContext().getString(cardType.getSecurityCodeName()));
         setFieldHint(cardType.getSecurityCodeName());
 
         invalidate();

--- a/CardForm/src/main/res/layout/bt_card_form_fields.xml
+++ b/CardForm/src/main/res/layout/bt_card_form_fields.xml
@@ -182,7 +182,7 @@
             android:layout_marginStart="@dimen/bt_save_card_checkbox_left_margin"
             android:layout_marginLeft="@dimen/bt_save_card_checkbox_left_margin"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="48dp"
             android:text="@string/bt_save_card_checkbox_name"/>
     </LinearLayout>
 </merge>


### PR DESCRIPTION
### Summary of changes
 - Make card form save card CheckBox touch target larger
 - Remove CVV edit text `contentDescription` in favor of `hint` (defining `contentDescription` on EditText can interfere with accessibility services: [source](https://support.google.com/accessibility/android/answer/6378120?hl=en))

### Checklist
 - ~[ ] Added a changelog entry~

### Authors
> List GitHub usernames for everyone who contributed to this pull request.
- @sarahkoop 
